### PR TITLE
Created the track class with the implementations listed

### DIFF
--- a/LetMusicConnectStrangers/LetMusicConnectStrangers/Models/Track.cs
+++ b/LetMusicConnectStrangers/LetMusicConnectStrangers/Models/Track.cs
@@ -1,0 +1,32 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace LetMusicConnectStrangers.Models
+{
+    public class Track
+    {
+        [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public int TrackId { get; set; }
+
+        [Required]
+        public string Title { get; set; } = string.Empty;
+
+        [Required]
+        public string Artist { get; set; } = string.Empty;
+
+        [Required]
+        public string Album { get; set; } = string.Empty;
+
+        [Required]
+        public string Genre { get; set; } = string.Empty;
+
+        [Required]
+        public TimeSpan Duration { get; set; }
+
+        [Required]
+        public string SpotifyId { get; set; } = string.Empty;
+
+        public string? Reviews { get; set; }
+    }
+}


### PR DESCRIPTION
Closes #13 
This pull request introduces a new `Track` model to the project. The `Track` class defines the structure for storing music track information in the application, including various required fields and support for database integration.

Model addition:

* Added a new `Track` class in `LetMusicConnectStrangers/Models/Track.cs` with properties for `TrackId`, `Title`, `Artist`, `Album`, `Genre`, `Duration`, `SpotifyId`, and an optional `Reviews` field. 